### PR TITLE
Feat: Added verify method to just verify OTP for custom use cases

### DIFF
--- a/src/OTPBroker.php
+++ b/src/OTPBroker.php
@@ -61,9 +61,20 @@ class OTPBroker
 
         $notifiable = $this->find($mobile, $create);
 
-        $this->revoke($notifiable);
+        if ($notifiable) {
+            $this->revoke($notifiable);
+        }
 
         return $notifiable;
+    }
+
+    public function verify(string $mobile, string $token): bool
+    {
+        $notifiable = $this->makeNotifiable($mobile);
+
+        throw_unless($this->tokenExists($notifiable, $token), InvalidOTPTokenException::class);
+
+        return $this->revoke($notifiable);
     }
 
     public function getToken(): ?string


### PR DESCRIPTION
### Why ?
- I have `country_code` and `mobile` in different columns
- Now current validate method doesn't work coz without `country_code` I can't use my app and with `country_code` it throws error that user not found.
- for these custom cases I've created a new `verify` method which just verify OTP and return bool.

### Is it a breaking change ?
No